### PR TITLE
Compatibility for python2/3

### DIFF
--- a/rfm69py/RFM69.py
+++ b/rfm69py/RFM69.py
@@ -241,7 +241,7 @@ class RFM69(object):
             ack = 0x80
         elif requestACK:
             ack = 0x40
-        if isinstance(buff, basestring):
+        if isinstance(buff, "".__class__):  # py2/3 compat
             self.spi.xfer2([REG_FIFO | 0x80, len(buff) + 3, toAddress, self.address, ack] + [int(ord(i)) for i in list(buff)])
         else:
             self.spi.xfer2([REG_FIFO | 0x80, len(buff) + 3, toAddress, self.address, ack] + buff)


### PR DESCRIPTION
basestring is gone in python3. Need a better way without involving six